### PR TITLE
Add license to prelude

### DIFF
--- a/LICENSE_FSL_PRELUDE.md
+++ b/LICENSE_FSL_PRELUDE.md
@@ -1,0 +1,93 @@
+FMRIB Software Library, Release 6.0 (c) 2018, The University of Oxford
+(the "Software")
+
+The Software remains the property of Oxford University Innovation 
+("the University").
+
+The Software is distributed "AS IS" under this Licence solely for
+non-commercial use in the hope that it will be useful, but in order
+that the University as a charitable foundation protects its assets for
+the benefit of its educational and research purposes, the University
+makes clear that no condition is made or to be implied, nor is any
+warranty given or to be implied, as to the accuracy of the Software,
+or that it will be suitable for any particular purpose or for use
+under any specific conditions. Furthermore, the University disclaims
+all responsibility for the use which is made of the Software. It
+further disclaims any liability for the outcomes arising from using
+the Software.
+
+The Licensee agrees to indemnify the University and hold the
+University harmless from and against any and all claims, damages and
+liabilities asserted by third parties (including claims for
+negligence) which arise directly or indirectly from the use of the
+Software or the sale of any products based on the Software.
+
+No part of the Software may be reproduced, modified, transmitted or
+transferred in any form or by any means, electronic or mechanical,
+without the express permission of the University. The permission of
+the University is not required if the said reproduction, modification,
+transmission or transference is done without financial return, the
+conditions of this Licence are imposed upon the receiver of the
+product, and all original and amended source code is included in any
+transmitted product. You may be held legally responsible for any
+copyright infringement that is caused or encouraged by your failure to
+abide by these terms and conditions.
+
+You are not permitted under this Licence to use this Software
+commercially. Use for which any financial return is received shall be
+defined as commercial use, and includes (1) integration of all or part
+of the source code or the Software into a product for sale or license
+by or on behalf of Licensee to third parties or (2) use of the
+Software or any derivative of it for research with the final aim of
+developing software products for sale or license to a third party or
+(3) use of the Software or any derivative of it for research with the
+final aim of developing non-software products for sale or license to a
+third party, or (4) use of the Software to provide any service to an
+external organisation for which payment is received. If you are
+interested in using the Software commercially, please contact Oxford
+University Innovation ("OUI"), the technology transfer company of the
+University, to negotiate a licence. Contact details are:
+fsl@innovation.ox.ac.uk quoting Reference Project 9564, FSL.
+
+
+-------------------------------------------------------------------
+
+The Standard Space Atlases
+
+The Cerebellum, Harvard-Oxford, JHU, Juelich, Striatum and Thalamus atlases, 
+whilst not being the property of Oxford, are released under the terms of the
+main FSL licence above, at the request of their owners. These atlases
+should therefore not be used for commercial purposes; for such
+purposes please contact the primary co-ordinator for the relevant
+atlas:
+
+Harvard-Oxford: steve@fmrib.ox.ac.uk
+JHU: susumu@mri.jhu.edu
+Juelich: S.Eickhoff@fz-juelich.de
+Thalamus: behrens@fmrib.ox.ac.uk
+Cerebellum: j.diedrichsen@bangor.ac.uk
+Striatum: andri.tziortzi@gmail.com
+
+-------------------------------------------------------------------
+
+FSLView
+
+FSLView sources are released under the terms of the GPLv2
+(http://www.gnu.org/licenses/old-licenses/gpl-2.0.html). FSLView 
+binaries use Qt (http://qt.nokia.com) which is released under LGPLv2.1.
+The FSLView binaries are released under the GPL, with the added 
+exception that we also give permission to link this program with the Qt
+non-commercial edition, and distribute the resulting executable,
+without including the source code for the Qt non-commercial edition in
+the source distribution.
+
+FSLView is distributed "AS IS" under this Licence in the hope that it
+will be useful, but in order that the University as a charitable
+foundation protects its assets for the benefit of its educational and
+research purposes, the University makes clear that no condition is
+made or to be implied, nor is any warranty given or to be implied, as
+to the accuracy of the Software, or that it will be suitable for any
+particular purpose or for use under any specific conditions.
+Furthermore, the University disclaims all responsibility for the use
+which is made of the Software. It further disclaims any liability for
+the outcomes arising from using the Software.


### PR DESCRIPTION
Prelude is an external dependency and should have its own license. This PR adds FSL's license.

License taken from: https://fsl.fmrib.ox.ac.uk/fsl/fslwiki